### PR TITLE
Update social membership creation.

### DIFF
--- a/app/controllers/think_feel_do_dashboard/memberships_controller.rb
+++ b/app/controllers/think_feel_do_dashboard/memberships_controller.rb
@@ -25,7 +25,8 @@ module ThinkFeelDoDashboard
                     .memberships
                     .build(membership_params)
       authorize! :create, @membership
-      if @membership.save
+
+      if validate_social_membership && @membership.save
         redirect_to participant_path(@participant),
                     notice: "Group was successfully assigned"
       else
@@ -110,6 +111,25 @@ module ThinkFeelDoDashboard
       (membership_params[:end_date] &&
         (membership_params[:end_date].to_date) > Date.today) ||
         membership_params[:end_date].nil?
+    end
+
+    def validate_social_membership
+      if @membership.group && @membership.group.arm.is_social?
+        validate_display_name
+      else
+        true
+      end
+    end
+
+    def validate_display_name
+      if @membership.display_name && !@membership.display_name.blank?
+        true
+      else
+        flash[:alert] = @membership.errors.full_messages.join(", ") +
+                        "#{@membership.group.title} is part of a social arm. "\
+                        "Display name is required for social arms."
+        false
+      end
     end
   end
 end

--- a/spec/controllers/think_feel_do_dashboard/membership_controller_spec.rb
+++ b/spec/controllers/think_feel_do_dashboard/membership_controller_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+module ThinkFeelDoDashboard
+  describe MembershipsController, type: :controller do
+    describe "POST create" do
+      let(:user) { double("user", admin?: true) }
+      let(:group) do
+        double("group",
+               arm: double("arm", is_social?: true),
+               title: "best group eva!!111")
+      end
+      let(:participant) do
+        double("pariticipant",
+               memberships: double("memberships",
+                                   build: double("membership",
+                                                 group: group,
+                                                 display_name: nil,
+                                                 errors:
+                                                   double("errors", full_messages: []))))
+      end
+
+      context "create new membership in social arm" do
+        before do
+          sign_in_user user
+        end
+
+        it "returns to membership creation if no display name is given" do
+          expect(Participant).to receive(:find) { participant }
+          post :create,
+               use_route: :think_feel_do_dashboard,
+               participant_id: "123",
+               membership: {
+                 start_date: Date.today,
+                 end_date: Date.tomorrow,
+                 group_id: "1"
+               }
+
+          expect(response).to render_template(:new)
+          expect(flash[:alert])
+            .to eq("best group eva!!111 is part of a social"\
+                   " arm. Display name is required for social arms.")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Social membership creation now fails with no display name.
* Added controller spec to ensure failure when no display name given.

[Finished #90648642]