### PR TITLE
Eager load groups when showing arms index

### DIFF
--- a/app/controllers/think_feel_do_dashboard/arms_controller.rb
+++ b/app/controllers/think_feel_do_dashboard/arms_controller.rb
@@ -7,6 +7,7 @@ module ThinkFeelDoDashboard
 
     # GET /think_feel_do_dashboard/arms
     def index
+      @arms = Arm.includes(:groups)
     end
 
     # POST /think_feel_do_dashboard/arms


### PR DESCRIPTION
* Resolves N+1 query issue when users navigate
  to groups by arms
* In the arms controller, eager load groups.

[#90408368]