### PR TITLE
Have moderator name change based on app

### DIFF
--- a/app/models/think_feel_do_dashboard/concerns/group.rb
+++ b/app/models/think_feel_do_dashboard/concerns/group.rb
@@ -60,7 +60,9 @@ module ThinkFeelDoDashboard
         password = SecureRandom.hex(64)
         ::Participant.create!(
           contact_preference: "email",
-          display_name: "ThinkFeelDo",
+          display_name: Rails.application
+                             .config
+                             .moderating_participant_display_name,
           email: "#{study_id}@example.com",
           is_admin: true,
           password: password,

--- a/config/initializers/think_feel_do_dashboard.rb
+++ b/config/initializers/think_feel_do_dashboard.rb
@@ -1,0 +1,2 @@
+#Set default display/user name for the group moderator of social arms
+Rails.application.config.moderating_participant_display_name = "ThinkFeelDo"

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -4,9 +4,27 @@ describe Group do
   fixtures :all
 
   describe "creation of moderator" do
+    let(:social_arm) { arms(:arm1) }
+    let(:clinician2) { users(:user2) }
+
+    context "Configuring App Display Name" do
+      before do
+        allow(Rails).to receive_message_chain(:application, :config, :moderating_participant_display_name).and_return("SunnySide")
+      end
+
+      it "names a moderating participant based on per-app config" do
+        group = social_arm.groups.create!(title: "Group with moderator", moderator_id: clinician2.id)
+        moderating_participant = group.moderating_participant
+        moderating_participant.reload
+
+        expect(moderating_participant).to_not be_nil
+        expect(moderating_participant.is_admin).to be_truthy
+        expect(moderating_participant.display_name).to eq "SunnySide"
+        expect(moderating_participant.email).to_not be_nil
+      end
+    end
+
     context "Social Arms" do
-      let(:social_arm) { arms(:arm1) }
-      let(:clinician2) { users(:user2) }
       let(:group) { social_arm.groups.create!(title: "Group with moderator", moderator_id: clinician2.id) }
 
       it "creates a moderating participant" do


### PR DESCRIPTION
 * Add default `moderating_participant_display_name` value
 * Have new groups set the moderator display name based on the above value

[Finished: #97469840]