### PR TITLE
Restict Access To Learn Dependent Pages

### DIFF
--- a/app/controllers/think_feel_do_dashboard/arms_controller.rb
+++ b/app/controllers/think_feel_do_dashboard/arms_controller.rb
@@ -26,6 +26,7 @@ module ThinkFeelDoDashboard
 
     # GET /think_feel_do_dashboard/arms/1
     def show
+      @lesson = @arm.bit_core_tools.find_by_type("Tools::Learn")
     end
 
     # GET /think_feel_do_dashboard/arms/1/edit

--- a/app/views/think_feel_do_dashboard/arms/show.html.erb
+++ b/app/views/think_feel_do_dashboard/arms/show.html.erb
@@ -19,13 +19,17 @@
           </li>
         <% end %>
         <li>
-          <% if can? :index, ContentModules::LessonModule %>
+          <% if @lesson && can?(:index, ContentModules::LessonModule) %>
             <%= link_to "Lesson Modules", (defined?(think_feel_do_engine) ? think_feel_do_engine.arm_lessons_path(@arm) : root_path) %>
+          <% elsif can? :index, ContentModules::LessonModule %>
+            <%= link_to "Lesson Modules*", "javascript:void(0);", data: { confirm: "A learn tool has to be created in order to access this page." } %>
           <% end %>
         </li>
         <li>
-          <% if can? :index, BitCore::Slideshow %>
+          <% if @lesson && can?(:index, BitCore::Slideshow) %>
             <%= link_to "Slideshows", (defined?(think_feel_do_engine) ? think_feel_do_engine.arm_bit_maker_slideshows_path(@arm) : root_path) %>
+          <% elsif can? :index, BitCore::Slideshow %>
+            <%= link_to "Slideshows*", "javascript:void(0);", data: { confirm: "A learn tool has to be created in order to access this page." } %>
           <% end %>
         </li>
       </ul>

--- a/spec/dummy/app/models/arm.rb
+++ b/spec/dummy/app/models/arm.rb
@@ -13,4 +13,11 @@ class Arm < ActiveRecord::Base
   def woz?
     has_woz
   end
+
+  def bit_core_tools
+    self
+  end
+
+  def find_by_type(type)
+  end
 end

--- a/spec/views/think_feel_do_dashboard/arms/show.html.erb_spec.rb
+++ b/spec/views/think_feel_do_dashboard/arms/show.html.erb_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "think_feel_do_dashboard/arms/show.html.erb",
+               type: :view do
+  fixtures :arms
+
+  context "When viewing arm details" do
+    before do
+      assign :arm, arms(:arm4)
+      allow(view).to receive(:can?).and_return(true)
+      allow(view).to receive(:edit_arm_path).and_return("#")
+      allow(view).to receive(:arm_path).and_return("#")
+      allow(view).to receive(:social_features?).and_return(false)
+
+      render
+    end
+
+    it "informs the user why they can't access lesson dependent pages" do
+      expect(rendered).to match "A learn tool has to be created in order to access this page."
+    end
+
+    it "doesn't allow the user to access the lesson module index page" do
+      expect(rendered).to have_text "Lesson Modules*"
+    end
+
+    it "doesn't allow the user to access the slideshow index page" do
+      expect(rendered).to have_text "Slideshows*"
+    end
+  end
+end


### PR DESCRIPTION
* Disable the link that allows users to access lesson-depend pages
* Add informative alert
* Update view specs

[#110321804]
[#110330372]