### PR TITLE
Fix Password Generation & Spec

### DIFF
--- a/app/models/think_feel_do_dashboard/concerns/group.rb
+++ b/app/models/think_feel_do_dashboard/concerns/group.rb
@@ -57,7 +57,7 @@ module ThinkFeelDoDashboard
       end
 
       def create_participant(study_id)
-        password = SecureRandom.base64(16)
+        password = SecureRandom.base64.gsub(/(.{1})/, '\1 ')
         ::Participant.create!(
           contact_preference: "email",
           display_name: Rails.application

--- a/spec/models/concerns/group_spec.rb
+++ b/spec/models/concerns/group_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe "Group concern" do
+  fixtures :all
+
+  describe "before_validation" do
+    describe "creating a moderator" do
+      let(:participant) do
+        Participant.create!(
+          contact_preference: "email",
+          study_id: "bar",
+          email: "foo@ex.com")
+      end
+
+      it "augments default password to ensure validity" do
+        allow(SecureRandom).to receive(:base64) { "weak" }
+
+        expect(Participant)
+          .to receive(:create!)
+          .with(
+            password: "w e a k ",
+            password_confirmation:  anything,
+            contact_preference: anything,
+            display_name: anything,
+            email: anything,
+            is_admin: true,
+            study_id: anything)
+          .and_return(participant)
+
+        Group.create!(
+          title: "Valid",
+          arm: arms(:arm1),
+          moderator: users(:clinician1))
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Add white space throughout password to keep repeating from failing password
* White space is not an option for SecureRandom.base64 (A-Z, a-z, 0-9, '+', '/' and '=')

[#111701452]
[#111779364]