### PR TITLE
Udpate Gem Parity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,15 +20,10 @@ group :development, :test do
   gem "rubocop", "~> 0.26"
   gem "devise", "~> 3.2"
   gem "event_capture",
-      git: "https://github.com/cbitstech/event_capture.git",
-      ref: "1f9a199"
-end
-
-group :development do
-  gem "brakeman", require: false
+      tag: "0.1.1",
+      git: "https://github.com/cbitstech/event_capture.git"
 end
 
 group :test do
-  gem "capybara", "~> 2"
-  gem "timecop"
+  gem "timecop", "~> 0.7"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,10 @@
 GIT
   remote: https://github.com/cbitstech/event_capture.git
-  revision: 1f9a1999f36cf08b7381aae8d9b7715c42a7de01
-  ref: 1f9a199
+  revision: 300f1b1c3aa53aba551612e7a97fd8c0b32129e1
+  tag: 0.1.1
   specs:
-    event_capture (0.0.1)
-      jbuilder
-      rails (>= 4.1.5)
+    event_capture (0.1.1)
+      activerecord (~> 4.1)
 
 GIT
   remote: https://github.com/cbitstech/git_tagger.git
@@ -21,7 +20,7 @@ PATH
       cancancan (~> 1.9)
       devise (~> 3.2)
       font-awesome-rails (= 4.2.0.0)
-      phonelib
+      phonelib (~> 0.5)
       rails (~> 4.2)
       turbolinks (~> 2.2)
 
@@ -117,9 +116,6 @@ GEM
       tilt
     highline (1.7.8)
     i18n (0.7.0)
-    jbuilder (2.4.0)
-      activesupport (>= 3.0.0, < 5.1)
-      multi_json (~> 1.2)
     jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
@@ -245,8 +241,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  brakeman
-  capybara (~> 2)
+  brakeman (~> 3)
   devise (~> 3.2)
   event_capture!
   git_tagger!
@@ -258,4 +253,4 @@ DEPENDENCIES
   simplecov (~> 0.9.1)
   strong_password (~> 0)
   think_feel_do_dashboard!
-  timecop
+  timecop (~> 0.7)

--- a/think_feel_do_dashboard.gemspec
+++ b/think_feel_do_dashboard.gemspec
@@ -27,12 +27,13 @@ Gem::Specification.new do |s|
   s.add_dependency "cancancan", "~> 1.9"
   # Validates phone numbers for participants
   # phonelib uses a Google library for varification
-  s.add_dependency "phonelib"
+  s.add_dependency "phonelib", "~> 0.5"
   s.add_dependency "font-awesome-rails", "= 4.2.0.0"
 
   s.add_development_dependency "pg", "~> 0.18"
   s.add_development_dependency "rspec-rails", "~> 3.0"
   s.add_development_dependency "poltergeist", "~> 1.6"
   s.add_development_dependency "strong_password", "~> 0"
+  s.add_development_dependency "brakeman", "~> 3"
   s.add_development_dependency "simplecov", "~> 0.9.1"
 end


### PR DESCRIPTION
* Update Event Capture gem to a tag
* Add tag for timecop and brakement gems
* Remove unnecessary `capybara` gem in gemfile - it is included with `poltergeist`
* Remove `development` gems

[#110176596]